### PR TITLE
fix(tomasa): add Nov-20 Tomasa sessions to transcription script

### DIFF
--- a/tomasa/scripts/transcribe-with-timestamps.ts
+++ b/tomasa/scripts/transcribe-with-timestamps.ts
@@ -35,6 +35,21 @@ const FILES = [
     path: join(DATA_DIR, "Tommy Wednesday-5-57", "Tommy - Wednesday at 17-57.m4a"),
     cache: join(CACHE_DIR, "wednesday-17-57.json"),
   },
+  {
+    id: "tomasa-nov20-0805",
+    path: join(DATA_DIR, "tomasa-Nov-20-at-08-05", "Copy of Nov 20 at 08-05.m4a"),
+    cache: join(CACHE_DIR, "tomasa-nov20-0805.json"),
+  },
+  {
+    id: "tomasa-nov20-1312",
+    path: join(DATA_DIR, "tomasa-Nov-20-at-13-12", "Nov 20 at 13-12.m4a"),
+    cache: join(CACHE_DIR, "tomasa-nov20-1312.json"),
+  },
+  {
+    id: "tomasa-nov20-1336",
+    path: join(DATA_DIR, "tomasa-Nov-20-at-13-36", "Nov 20 at 13-36.m4a"),
+    cache: join(CACHE_DIR, "tomasa-nov20-1336.json"),
+  },
 ]
 
 for (const file of FILES) {


### PR DESCRIPTION
## Summary
- Add 3 Tomasa Nov-20 m4a entries to `FILES` array in `transcribe-with-timestamps.ts`
- `language: "es"` already enforced for all entries via shared loop — fixes German hallucination
- Cache outputs: `tomasa-nov20-0805.json`, `tomasa-nov20-1312.json`, `tomasa-nov20-1336.json`

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)