### PR TITLE
feat(tomasa): AI transcript gap-filling script

### DIFF
--- a/tomasa/docs/superpowers/plans/2026-06-30-fill-transcript-gaps.md
+++ b/tomasa/docs/superpowers/plans/2026-06-30-fill-transcript-gaps.md
@@ -1,0 +1,506 @@
+# Fill Transcript Gaps Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `tomasa/scripts/fill-transcript-gaps.ts` to repair low-confidence/inaudible segments in the three Nov-20 labeled transcripts using Claude, writing auditable non-destructive output.
+
+**Architecture:** Pure exported helpers (`flagSegments`, `buildContext`) are TDD'd in a bun test; an integration layer (`fillSegment`, `fillFile`, main) calls `claude -p --model sonnet` per flagged segment, mirroring `add-speaker-labels.ts`. Output goes to a new gitignored `data/gap-filled-transcripts/` dir with `original_text` + `gap_filled` markers.
+
+**Tech Stack:** Bun runtime, TypeScript (strict, no semicolons, double quotes), `bun:test`, `claude` CLI subprocess.
+
+## Global Constraints
+
+- Code style: 2-space indent, double quotes, **no semicolons**, `import type` for type-only imports, kebab-case filenames. (verbatim from tomasa/CLAUDE.md)
+- Runtime: Bun 1.1+. Tests use `import { describe, it, expect } from "bun:test"`.
+- Model for gap-fill: `sonnet`.
+- Scope: exactly the three files `tomasa_2025-11-20_0805`, `tomasa_2025-11-20_1312`, `tomasa_2025-11-20_1336`.
+- Data dir resolves from `process.env.TOMASA_DATA_DIR` else repo-relative `tomasa/../data`. `data/` is gitignored — never commit transcript JSON.
+- Fail-safe: a failed Claude call returns the original text unchanged; never lose content.
+- Flag thresholds (module constants): `avg_logprob < -0.5`, `no_speech_prob > 0.6`, `compression_ratio > 2.4`, `text` matches `/\[inaudible\]/i`.
+
+---
+
+## File Structure
+
+- Create: `tomasa/scripts/fill-transcript-gaps.ts` — types, pure helpers, Claude integration, main.
+- Create: `tomasa/scripts/fill-transcript-gaps.test.ts` — unit tests for pure helpers.
+
+Run all commands from the `tomasa/` directory.
+
+---
+
+### Task 1: Pure helper `flagSegments` (TDD)
+
+**Files:**
+- Create: `tomasa/scripts/fill-transcript-gaps.ts`
+- Test: `tomasa/scripts/fill-transcript-gaps.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `interface RawSegment { id: number; seek: number; start: number; end: number; text: string; tokens: number[]; temperature: number; avg_logprob: number; compression_ratio: number; no_speech_prob: number }`
+  - `type Speaker = "Tomasa" | "Interviewer" | "unknown"`
+  - `interface LabeledSegment extends RawSegment { speaker: Speaker }`
+  - `flagSegments(segments: LabeledSegment[]): number[]` — array indices (not segment ids) of segments needing repair.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tomasa/scripts/fill-transcript-gaps.test.ts`:
+
+```ts
+import { describe, it, expect } from "bun:test"
+import { flagSegments, type LabeledSegment } from "./fill-transcript-gaps"
+
+const seg = (over: Partial<LabeledSegment> = {}): LabeledSegment => ({
+  id: 0,
+  seek: 0,
+  start: 0,
+  end: 1,
+  text: "hola",
+  tokens: [],
+  temperature: 0,
+  avg_logprob: -0.3,
+  compression_ratio: 1.5,
+  no_speech_prob: 0.1,
+  speaker: "Tomasa",
+  ...over,
+})
+
+describe("flagSegments", () => {
+  it("does not flag a clean segment", () => {
+    expect(flagSegments([seg()])).toEqual([])
+  })
+
+  it("flags low avg_logprob", () => {
+    expect(flagSegments([seg({ avg_logprob: -0.6 })])).toEqual([0])
+  })
+
+  it("flags high no_speech_prob", () => {
+    expect(flagSegments([seg({ no_speech_prob: 0.7 })])).toEqual([0])
+  })
+
+  it("flags high compression_ratio", () => {
+    expect(flagSegments([seg({ compression_ratio: 2.5 })])).toEqual([0])
+  })
+
+  it("flags literal [inaudible] case-insensitively", () => {
+    expect(flagSegments([seg({ text: "se fue a [INAUDIBLE] el rancho" })])).toEqual([0])
+  })
+
+  it("counts a multi-threshold segment once and returns indices", () => {
+    const segs = [seg(), seg({ avg_logprob: -0.6, no_speech_prob: 0.9 }), seg()]
+    expect(flagSegments(segs)).toEqual([1])
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test scripts/fill-transcript-gaps.test.ts`
+Expected: FAIL — cannot resolve `./fill-transcript-gaps` / `flagSegments` not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `tomasa/scripts/fill-transcript-gaps.ts`:
+
+```ts
+#!/usr/bin/env bun
+/**
+ * Fill low-confidence / inaudible gaps in labeled Tomasa transcripts using Claude.
+ * Reads data/labeled-transcripts/, writes data/gap-filled-transcripts/.
+ *
+ * Usage: bun scripts/fill-transcript-gaps.ts
+ *   TOMASA_DATA_DIR overrides the data dir (needed when run from a git worktree).
+ */
+
+export type Speaker = "Tomasa" | "Interviewer" | "unknown"
+
+export interface RawSegment {
+  id: number
+  seek: number
+  start: number
+  end: number
+  text: string
+  tokens: number[]
+  temperature: number
+  avg_logprob: number
+  compression_ratio: number
+  no_speech_prob: number
+}
+
+export interface LabeledSegment extends RawSegment {
+  speaker: Speaker
+}
+
+export interface GapSegment extends LabeledSegment {
+  gap_filled?: boolean
+  original_text?: string
+}
+
+const LOGPROB_MIN = -0.5
+const NO_SPEECH_MAX = 0.6
+const COMPRESSION_MAX = 2.4
+const INAUDIBLE_RE = /\[inaudible\]/i
+
+export function flagSegments(segments: LabeledSegment[]): number[] {
+  const flagged: number[] = []
+  segments.forEach((s, i) => {
+    if (
+      s.avg_logprob < LOGPROB_MIN ||
+      s.no_speech_prob > NO_SPEECH_MAX ||
+      s.compression_ratio > COMPRESSION_MAX ||
+      INAUDIBLE_RE.test(s.text)
+    ) {
+      flagged.push(i)
+    }
+  })
+  return flagged
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test scripts/fill-transcript-gaps.test.ts`
+Expected: PASS — 6 tests in the `flagSegments` describe block.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tomasa/scripts/fill-transcript-gaps.ts tomasa/scripts/fill-transcript-gaps.test.ts
+git commit -m "feat(tomasa): add flagSegments for transcript gap detection"
+```
+
+---
+
+### Task 2: Pure helper `buildContext` (TDD)
+
+**Files:**
+- Modify: `tomasa/scripts/fill-transcript-gaps.ts`
+- Test: `tomasa/scripts/fill-transcript-gaps.test.ts`
+
+**Interfaces:**
+- Consumes: `LabeledSegment` from Task 1.
+- Produces: `buildContext(segments: LabeledSegment[], index: number, radius?: number): string` — a newline-joined block of `"<speaker>: <text>"` lines for the window `[index-radius, index+radius]` clamped to bounds, with the target line prefixed `>> `. Default `radius = 3`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tomasa/scripts/fill-transcript-gaps.test.ts`:
+
+```ts
+import { buildContext } from "./fill-transcript-gaps"
+
+describe("buildContext", () => {
+  const segs = Array.from({ length: 10 }, (_, i) =>
+    seg({ id: i, text: `line ${i}`, speaker: i % 2 === 0 ? "Tomasa" : "Interviewer" })
+  )
+
+  it("includes radius neighbors on both sides and marks the target", () => {
+    const out = buildContext(segs, 5, 2)
+    const lines = out.split("\n")
+    expect(lines).toHaveLength(5) // 3,4,5,6,7
+    expect(lines[0]).toBe("Interviewer: line 3")
+    expect(lines[2]).toBe(">> Tomasa: line 5")
+    expect(lines[4]).toBe("Interviewer: line 7")
+  })
+
+  it("clamps at the start of the array", () => {
+    const out = buildContext(segs, 0, 3)
+    const lines = out.split("\n")
+    expect(lines).toHaveLength(4) // 0,1,2,3
+    expect(lines[0]).toBe(">> Tomasa: line 0")
+  })
+
+  it("clamps at the end of the array", () => {
+    const out = buildContext(segs, 9, 3)
+    const lines = out.split("\n")
+    expect(lines).toHaveLength(4) // 6,7,8,9
+    expect(lines[3]).toBe(">> Interviewer: line 9")
+  })
+
+  it("defaults radius to 3", () => {
+    const out = buildContext(segs, 5)
+    expect(out.split("\n")).toHaveLength(7) // 2..8
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test scripts/fill-transcript-gaps.test.ts`
+Expected: FAIL — `buildContext` not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `tomasa/scripts/fill-transcript-gaps.ts` (after `flagSegments`):
+
+```ts
+export function buildContext(
+  segments: LabeledSegment[],
+  index: number,
+  radius = 3
+): string {
+  const start = Math.max(0, index - radius)
+  const end = Math.min(segments.length - 1, index + radius)
+  const lines: string[] = []
+  for (let i = start; i <= end; i++) {
+    const s = segments[i]
+    const line = `${s.speaker}: ${s.text}`
+    lines.push(i === index ? `>> ${line}` : line)
+  }
+  return lines.join("\n")
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test scripts/fill-transcript-gaps.test.ts`
+Expected: PASS — all `flagSegments` and `buildContext` tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tomasa/scripts/fill-transcript-gaps.ts tomasa/scripts/fill-transcript-gaps.test.ts
+git commit -m "feat(tomasa): add buildContext window builder for gap-fill"
+```
+
+---
+
+### Task 3: Claude integration `fillSegment` + prompt
+
+**Files:**
+- Modify: `tomasa/scripts/fill-transcript-gaps.ts`
+
+**Interfaces:**
+- Consumes: `LabeledSegment`, `buildContext` output (context string).
+- Produces:
+  - `const SYSTEM_PROMPT: string` — Tomasa roster + shesheo + return-only-text instruction.
+  - `fillSegment(target: LabeledSegment, context: string, retries?: number): Promise<string>` — corrected text, or `target.text` unchanged on failure. Default `retries = 2`.
+
+Not unit-tested (subprocess), consistent with `add-speaker-labels.ts`.
+
+- [ ] **Step 1: Add SYSTEM_PROMPT and fillSegment**
+
+Append to `tomasa/scripts/fill-transcript-gaps.ts`:
+
+```ts
+const CLAUDE_MODEL = "sonnet"
+
+const SYSTEM_PROMPT = `You are repairing a single segment of a Spanish-language oral history
+interview transcribed by ASR. Two speakers: "Tomasa" (grandmother, ~88, from Chihuahua,
+Mexico) and "Interviewer" (her grandson, Kristian).
+
+Some words are inaudible, mis-heard, or low-confidence. Using the surrounding context,
+return a corrected version of ONLY the marked segment (the line starting with ">>").
+
+Known names — use these spellings when the audio is ambiguous:
+- Family: Epifanio (father), Francisca (mother); siblings Evaristo, Paulina, Estefana, Lala;
+  husband Toño; children Miguel, Antonio, Arnulfo, Jesús, Tere; Marta;
+  grandchildren Kristian, Ericka, Alan, Aby.
+- Places: Rancho Los Olices, El Oro (a mine), Parral, Santa Bárbara, Chihuahua,
+  Estación Guichivo/Bahuichivo, Monterrey, Juárez.
+
+Chihuahua accent (shesheo) — apply sparingly, only if already hinted phonetically:
+muchacho→mushasho, chile→shile, ocho→osho, escúchame→escúshame.
+
+Rules:
+- Replace any [INAUDIBLE]/[inaudible] markers with the most plausible words from context.
+- Fix obvious mis-hearings of the known names/places above.
+- Keep Tomasa's natural voice; do not paraphrase or add content beyond the segment.
+- Return ONLY the corrected segment text. No quotes, no commentary, no markdown fences.`
+
+export async function fillSegment(
+  target: LabeledSegment,
+  context: string,
+  retries = 2
+): Promise<string> {
+  const prompt = `${SYSTEM_PROMPT}\n\nContext:\n${context}\n\nCorrected text for the ">>" segment:`
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const proc = Bun.spawn(["claude", "-p", "--model", CLAUDE_MODEL, prompt], {
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+
+      const [stdout, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        proc.exited,
+      ])
+
+      if (exitCode !== 0) {
+        const stderr = await new Response(proc.stderr).text()
+        throw new Error(`claude exited ${exitCode}: ${stderr}`)
+      }
+
+      const cleaned = stdout
+        .trim()
+        .replace(/^```(?:\w+)?\n?/, "")
+        .replace(/\n?```$/, "")
+        .trim()
+
+      if (cleaned.length > 0) return cleaned
+      throw new Error("empty response")
+    } catch (err) {
+      if (attempt < retries) {
+        await new Promise((r) => setTimeout(r, 1000 * Math.pow(2, attempt)))
+        continue
+      }
+      console.warn(`  ⚠ fill failed for segment id=${target.id}, keeping original`)
+      console.error("  Last error:", err)
+      return target.text
+    }
+  }
+  return target.text
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `bun run type-check`
+Expected: PASS (no type errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tomasa/scripts/fill-transcript-gaps.ts
+git commit -m "feat(tomasa): add fillSegment Claude call with roster prompt"
+```
+
+---
+
+### Task 4: `fillFile` + main entrypoint
+
+**Files:**
+- Modify: `tomasa/scripts/fill-transcript-gaps.ts`
+
+**Interfaces:**
+- Consumes: `flagSegments`, `buildContext`, `fillSegment`, `GapSegment`.
+- Produces: `fillFile(inputPath: string, outputPath: string): Promise<void>`; `import.meta.main` entrypoint over the three-file allowlist.
+
+- [ ] **Step 1: Add imports at top of file**
+
+Edit the top of `tomasa/scripts/fill-transcript-gaps.ts`, immediately after the header doc comment, insert:
+
+```ts
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs"
+import { join } from "path"
+```
+
+- [ ] **Step 2: Add fillFile and main at end of file**
+
+Append to `tomasa/scripts/fill-transcript-gaps.ts`:
+
+```ts
+export async function fillFile(inputPath: string, outputPath: string): Promise<void> {
+  const filename = inputPath.split("/").pop()!
+
+  if (existsSync(outputPath)) {
+    console.log(`✓ Already gap-filled: ${filename}`)
+    return
+  }
+
+  const raw = JSON.parse(readFileSync(inputPath, "utf-8"))
+  const segments: GapSegment[] = raw.segments ?? []
+  const flagged = flagSegments(segments)
+
+  console.log(`  ${filename}: ${segments.length} segments, ${flagged.length} flagged`)
+
+  let filledCount = 0
+  for (const idx of flagged) {
+    const target = segments[idx]
+    const context = buildContext(segments, idx)
+    const corrected = await fillSegment(target, context)
+    if (corrected !== target.text) {
+      target.original_text = target.text
+      target.text = corrected
+      target.gap_filled = true
+      filledCount++
+    }
+  }
+
+  writeFileSync(outputPath, JSON.stringify({ ...raw, segments }, null, 2))
+  console.log(`✓ ${filename}: ${filledCount} filled / ${flagged.length} flagged`)
+}
+
+if (import.meta.main) {
+  const DATA_DIR =
+    process.env.TOMASA_DATA_DIR ?? join(import.meta.dir, "..", "..", "data")
+  const INPUT_DIR = join(DATA_DIR, "labeled-transcripts")
+  const OUTPUT_DIR = join(DATA_DIR, "gap-filled-transcripts")
+
+  if (!existsSync(OUTPUT_DIR)) mkdirSync(OUTPUT_DIR, { recursive: true })
+
+  const FILES = [
+    "tomasa_2025-11-20_0805.json",
+    "tomasa_2025-11-20_1312.json",
+    "tomasa_2025-11-20_1336.json",
+  ]
+
+  console.log(`Gap-filling ${FILES.length} transcript(s)...\n`)
+
+  for (const f of FILES) {
+    await fillFile(join(INPUT_DIR, f), join(OUTPUT_DIR, f))
+  }
+
+  console.log("\nDone. Gap-filled files in:", OUTPUT_DIR)
+}
+```
+
+- [ ] **Step 3: Verify tests still pass and types are clean**
+
+Run: `bun test scripts/fill-transcript-gaps.test.ts && bun run type-check`
+Expected: PASS — pure-helper tests green, no type errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tomasa/scripts/fill-transcript-gaps.ts
+git commit -m "feat(tomasa): add fillFile + main for Nov-20 gap-fill (closes #5)"
+```
+
+---
+
+### Task 5: Run against real data + verify output
+
+**Files:** none (execution + manual verification).
+
+`data/` is gitignored and lives in the primary checkout, not the worktree. Point the
+script at the real data dir. Replace `<REPO>` with the primary checkout path
+(`/Volumes/Verbatim-Vi560-Media/Development/aves/purpurit`).
+
+- [ ] **Step 1: Run the script against real data**
+
+Run (from `tomasa/`):
+```bash
+TOMASA_DATA_DIR=<REPO>/data bun scripts/fill-transcript-gaps.ts
+```
+Expected: three files processed; 0805 reports a small number flagged (≈9) and ≥0 filled; 1312 and 1336 report 0 flagged.
+
+- [ ] **Step 2: Verify output files exist**
+
+Run:
+```bash
+ls -la <REPO>/data/gap-filled-transcripts/
+```
+Expected: `tomasa_2025-11-20_0805.json`, `_1312.json`, `_1336.json` present.
+
+- [ ] **Step 3: Spot-check fills carry audit fields**
+
+Run:
+```bash
+python3 -c "import json; d=json.load(open('<REPO>/data/gap-filled-transcripts/tomasa_2025-11-20_0805.json')); f=[s for s in d['segments'] if s.get('gap_filled')]; print('filled:', len(f)); [print(s['id'], repr(s.get('original_text')), '->', repr(s['text'])) for s in f[:5]]"
+```
+Expected: each filled segment shows `gap_filled: true`, an `original_text`, and a different `text`. Confirm 1312/1336 have zero `gap_filled` segments.
+
+- [ ] **Step 4: No data committed**
+
+Run: `git status --short`
+Expected: no `data/` files staged or shown (they are gitignored). Only the script/test/plan/spec are tracked.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** flagging (Task 1), context window (Task 2), Claude fill w/ roster prompt (Task 3), merge+write+resume+allowlist+env-override (Task 4), verification incl. passthrough check for 1312/1336 (Task 5). All spec sections covered.
+- **Types:** `RawSegment`/`LabeledSegment`/`GapSegment`/`Speaker` defined Task 1, reused consistently. `flagSegments` returns array indices (used as such in Task 4). `buildContext(segments, index, radius=3)` signature matches Task 4 call.
+- **No placeholders:** every code step shows full code.

--- a/tomasa/docs/superpowers/specs/2026-06-30-fill-transcript-gaps-design.md
+++ b/tomasa/docs/superpowers/specs/2026-06-30-fill-transcript-gaps-design.md
@@ -1,0 +1,135 @@
+# Fill Transcript Gaps in Tomasa Sessions Using AI
+
+**Issue:** [#5](https://github.com/kjgarza/purpurit/issues/5) — depends on #3 (re-transcription, closed) and #4 (speaker labels; labeled files already on disk).
+**Date:** 2026-06-30
+
+## Goal
+
+Use Claude to repair low-confidence / inaudible segments in the three labeled Tomasa
+Nov-20 transcripts, inferring correct text from surrounding context and a known roster
+of family/place names. Output is non-destructive and auditable.
+
+## Context
+
+`data/labeled-transcripts/*.json` segments (from `add-speaker-labels.ts`) carry Whisper
+confidence metrics plus a `speaker` label. Measured stats for the three Nov-20 files:
+
+| File | segments | `avg_logprob < -0.5` | `no_speech_prob > 0.6` | `compression_ratio > 2.4` |
+|------|---------:|---------------------:|-----------------------:|--------------------------:|
+| tomasa_2025-11-20_0805 | 181 | 9 | 9 | 0 |
+| tomasa_2025-11-20_1312 | 571 | 0 | 0 | 0 |
+| tomasa_2025-11-20_1336 | 156 | 0 | 0 | 0 |
+
+These are high-quality transcripts. Gap-fill is conservative: it touches only a handful
+of segments, all in the 0805 file. The script must do nothing when no segment is flagged.
+
+## Decisions
+
+- **Output:** new `data/gap-filled-transcripts/<file>.json` (non-destructive; labeled files untouched).
+- **Model:** `sonnet` (stronger Spanish/dialect reasoning than the haiku used for labeling; segment count is tiny so cost is negligible).
+- **Scope:** the three Nov-20 files only, via a hardcoded allowlist (not a whole-dir scan).
+- **Auditability:** filled segments keep `original_text`; replacement goes in `text`; add `gap_filled: true`.
+- **Data location:** `data/` is gitignored and lives only in the primary checkout. The script
+  resolves its data dir from `TOMASA_DATA_DIR` env var, falling back to the repo-relative
+  `tomasa/../data`. This lets it run from a git worktree against the real data dir.
+
+## Architecture
+
+Mirrors `scripts/add-speaker-labels.ts`: pure exported helpers + a `claude -p` subprocess
+call, with the helpers unit-tested and the subprocess left to integration.
+
+### Types
+
+```ts
+interface GapSegment extends LabeledSegment {
+  gap_filled?: boolean
+  original_text?: string
+}
+```
+
+(`LabeledSegment` = `RawSegment` + `speaker`, reused conceptually from the labeling script.)
+
+### 1. `flagSegments(segments): number[]` — pure
+
+Returns indices of segments needing repair. A segment is flagged if **any** holds:
+
+- `avg_logprob < -0.5`
+- `no_speech_prob > 0.6`
+- `compression_ratio > 2.4`
+- `text` matches `/\[inaudible\]/i`
+
+Thresholds are module constants so they're easy to tune.
+
+### 2. `buildContext(segments, index, radius = 3): string` — pure
+
+Builds the context block passed to Claude: the `radius` segments before and after `index`,
+each rendered as `"<speaker>: <text>"`, with the target segment marked. Clamps at array
+bounds. Returns a plain string.
+
+### 3. `fillSegment(target, contextBlock, retries = 2): Promise<string>`
+
+One `claude -p --model sonnet <prompt>` subprocess (same spawn/retry/backoff pattern as
+`labelChunk`). Prompt = system roster + context + instruction to return only the corrected
+segment text. Strips markdown fences. On exhausted retries, returns the original text
+unchanged (fail-safe: never lose content).
+
+System prompt includes the issue's roster verbatim:
+
+- Speakers: Tomasa (grandmother, ~88, from Chihuahua) and her grandson interviewer.
+- Family: Epifanio (father), Francisca (mother), siblings Evaristo/Paulina/Estefana/Lala,
+  husband Toño, children Miguel/Antonio/Arnulfo/Jesús/Tere, Marta,
+  grandchildren Kristian/Ericka/Alan/Aby.
+- Places: Rancho Los Olices, El Oro (mine), Parral, Santa Bárbara, Chihuahua,
+  Estación Guichivo/Bahuichivo, Monterrey, Juárez.
+- Chihuahua shesheo hints (use sparingly): muchacho→mushasho, chile→shile, ocho→osho,
+  escúchame→escúshame.
+- Instruction: fill `[INAUDIBLE]` / fix mishearings from context; return ONLY corrected
+  segment text, no commentary, no fences.
+
+### 4. `fillFile(inputPath, outputPath): Promise<void>`
+
+1. Skip-if-exists resume guard (matches labeling script).
+2. Read labeled JSON, flag segments.
+3. If none flagged, still write the output (passthrough copy) so the file exists and runs
+   are idempotent; log "0 gaps".
+4. For each flagged index: build context, call `fillSegment`, and if the result differs
+   from the original, set `text` = corrected, `original_text` = old, `gap_filled = true`.
+   If unchanged, leave the segment untouched (no `gap_filled` flag).
+5. Write `{ ...raw, segments }` to `outputPath`; log filled/flagged counts.
+
+### Main
+
+```
+DATA_DIR  = process.env.TOMASA_DATA_DIR ?? join(import.meta.dir, "..", "..", "data")
+INPUT_DIR = DATA_DIR/labeled-transcripts
+OUTPUT_DIR= DATA_DIR/gap-filled-transcripts   (mkdir -p)
+FILES     = ["tomasa_2025-11-20_0805", "1312", "1336"].json   // hardcoded allowlist
+```
+
+Process the three files (sequential is fine — few segments). Print a summary.
+
+## Testing
+
+`scripts/fill-transcript-gaps.test.ts` (bun test), pure helpers only:
+
+- `flagSegments`: one case per threshold (low logprob, high no_speech, high compression,
+  literal `[inaudible]`), a clean segment that is **not** flagged, and a segment tripping
+  multiple thresholds counted once.
+- `buildContext`: window contents + clamping at array start/end + target marking.
+
+The `claude` subprocess is not unit-tested, consistent with `add-speaker-labels.ts`.
+
+## Out of scope
+
+- Re-running labeling or transcription.
+- The other four (Oct) sessions.
+- Wiring gap-filled transcripts into the Next.js app content.
+- Human review UI for accepting/rejecting fills.
+
+## Verification
+
+- `bun test scripts/fill-transcript-gaps.test.ts` passes.
+- `bun run type-check` clean.
+- `TOMASA_DATA_DIR=<real>/data bun scripts/fill-transcript-gaps.ts` produces three files in
+  `gap-filled-transcripts/`; spot-check the 0805 fills carry `original_text` + `gap_filled`,
+  and the 1312/1336 outputs are passthrough copies with zero `gap_filled` segments.

--- a/tomasa/scripts/fill-transcript-gaps.test.ts
+++ b/tomasa/scripts/fill-transcript-gaps.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "bun:test"
+import { flagSegments, buildContext, type LabeledSegment } from "./fill-transcript-gaps"
+
+const seg = (over: Partial<LabeledSegment> = {}): LabeledSegment => ({
+  id: 0,
+  seek: 0,
+  start: 0,
+  end: 1,
+  text: "hola",
+  tokens: [],
+  temperature: 0,
+  avg_logprob: -0.3,
+  compression_ratio: 1.5,
+  no_speech_prob: 0.1,
+  speaker: "Tomasa",
+  ...over,
+})
+
+describe("flagSegments", () => {
+  it("does not flag a clean segment", () => {
+    expect(flagSegments([seg()])).toEqual([])
+  })
+
+  it("flags low avg_logprob", () => {
+    expect(flagSegments([seg({ avg_logprob: -0.6 })])).toEqual([0])
+  })
+
+  it("flags high no_speech_prob", () => {
+    expect(flagSegments([seg({ no_speech_prob: 0.7 })])).toEqual([0])
+  })
+
+  it("flags high compression_ratio", () => {
+    expect(flagSegments([seg({ compression_ratio: 2.5 })])).toEqual([0])
+  })
+
+  it("flags literal [inaudible] case-insensitively", () => {
+    expect(flagSegments([seg({ text: "se fue a [INAUDIBLE] el rancho" })])).toEqual([0])
+  })
+
+  it("counts a multi-threshold segment once and returns indices", () => {
+    const segs = [seg(), seg({ avg_logprob: -0.6, no_speech_prob: 0.9 }), seg()]
+    expect(flagSegments(segs)).toEqual([1])
+  })
+})
+
+describe("buildContext", () => {
+  const segs = Array.from({ length: 10 }, (_, i) =>
+    seg({ id: i, text: `line ${i}`, speaker: i % 2 === 0 ? "Tomasa" : "Interviewer" })
+  )
+
+  it("includes radius neighbors on both sides and marks the target", () => {
+    const out = buildContext(segs, 5, 2)
+    const lines = out.split("\n")
+    expect(lines).toHaveLength(5) // 3,4,5,6,7
+    expect(lines[0]).toBe("Interviewer: line 3")
+    expect(lines[2]).toBe(">> Interviewer: line 5")
+    expect(lines[4]).toBe("Interviewer: line 7")
+  })
+
+  it("clamps at the start of the array", () => {
+    const out = buildContext(segs, 0, 3)
+    const lines = out.split("\n")
+    expect(lines).toHaveLength(4) // 0,1,2,3
+    expect(lines[0]).toBe(">> Tomasa: line 0")
+  })
+
+  it("clamps at the end of the array", () => {
+    const out = buildContext(segs, 9, 3)
+    const lines = out.split("\n")
+    expect(lines).toHaveLength(4) // 6,7,8,9
+    expect(lines[3]).toBe(">> Interviewer: line 9")
+  })
+
+  it("defaults radius to 3", () => {
+    const out = buildContext(segs, 5)
+    expect(out.split("\n")).toHaveLength(7) // 2..8
+  })
+})

--- a/tomasa/scripts/fill-transcript-gaps.test.ts
+++ b/tomasa/scripts/fill-transcript-gaps.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "bun:test"
-import { flagSegments, buildContext, type LabeledSegment } from "./fill-transcript-gaps"
+import {
+  flagSegments,
+  buildContext,
+  extractFilledText,
+  type LabeledSegment,
+} from "./fill-transcript-gaps"
 
 const seg = (over: Partial<LabeledSegment> = {}): LabeledSegment => ({
   id: 0,
@@ -74,5 +79,27 @@ describe("buildContext", () => {
   it("defaults radius to 3", () => {
     const out = buildContext(segs, 5)
     expect(out.split("\n")).toHaveLength(7) // 2..8
+  })
+})
+
+describe("extractFilledText", () => {
+  it("parses a bare JSON object", () => {
+    expect(extractFilledText('{"text": "¿De qué son?"}')).toBe("¿De qué son?")
+  })
+
+  it("parses JSON wrapped in markdown fences", () => {
+    expect(extractFilledText('```json\n{"text": "El caballo"}\n```')).toBe("El caballo")
+  })
+
+  it("trims the extracted text", () => {
+    expect(extractFilledText('{"text": "  El caballo  "}')).toBe("El caballo")
+  })
+
+  it("throws on non-JSON commentary (caller falls back to original)", () => {
+    expect(() => extractFilledText("Segment fine, return as-is")).toThrow()
+  })
+
+  it("throws when 'text' field is missing or non-string", () => {
+    expect(() => extractFilledText('{"corrected": "x"}')).toThrow()
   })
 })

--- a/tomasa/scripts/fill-transcript-gaps.ts
+++ b/tomasa/scripts/fill-transcript-gaps.ts
@@ -93,8 +93,8 @@ export function buildContext(
 export function extractFilledText(raw: string): string {
   const stripped = raw
     .trim()
-    .replace(/^```(?:json)?\n?/, "")
-    .replace(/\n?```$/, "")
+    .replace(/^```(?:json)?\r?\n?/i, "")
+    .replace(/\r?\n?```$/, "")
     .trim()
   const parsed = JSON.parse(stripped)
   if (typeof parsed?.text !== "string") {

--- a/tomasa/scripts/fill-transcript-gaps.ts
+++ b/tomasa/scripts/fill-transcript-gaps.ts
@@ -84,6 +84,25 @@ export function buildContext(
   return lines.join("\n")
 }
 
+/**
+ * Extract the corrected segment text from Claude's JSON response.
+ * Strips optional markdown fences, parses `{"text": "..."}`, and returns the
+ * trimmed text. Throws if the response is not valid JSON with a string `text`
+ * field — the caller treats that as a failed attempt (fail-safe to original).
+ */
+export function extractFilledText(raw: string): string {
+  const stripped = raw
+    .trim()
+    .replace(/^```(?:json)?\n?/, "")
+    .replace(/\n?```$/, "")
+    .trim()
+  const parsed = JSON.parse(stripped)
+  if (typeof parsed?.text !== "string") {
+    throw new Error("response missing string 'text' field")
+  }
+  return parsed.text.trim()
+}
+
 // ─── Claude Fill ──────────────────────────────────────────────────────────────
 
 const CLAUDE_MODEL = "sonnet"
@@ -106,10 +125,16 @@ Chihuahua accent (shesheo) — apply sparingly, only if already hinted phonetica
 muchacho→mushasho, chile→shile, ocho→osho, escúchame→escúshame.
 
 Rules:
-- Replace any [INAUDIBLE]/[inaudible] markers with the most plausible words from context.
-- Fix obvious mis-hearings of the known names/places above.
-- Keep Tomasa's natural voice; do not paraphrase or add content beyond the segment.
-- Return ONLY the corrected segment text. No quotes, no commentary, no markdown fences.`
+- Be conservative. If the marked segment is already coherent Spanish and the context gives
+  no clear evidence of an ASR error, return it EXACTLY as-is. Do NOT paraphrase, "improve",
+  or guess alternative words. Inventing words she did not say corrupts the record.
+- Only change text when there is a [INAUDIBLE]/[inaudible] marker to fill, or a clear
+  mis-hearing of one of the known names/places above.
+- Keep Tomasa's natural voice; do not add content beyond the segment.
+
+Respond with ONLY a JSON object: {"text": "<the corrected segment text, or the original
+text unchanged if there is no clear error>"}. No speaker name, no commentary, no markdown
+fences, no extra keys. The "text" value must never contain explanations — only the segment.`
 
 /**
  * Ask Claude to correct a single flagged segment given its context.
@@ -120,7 +145,7 @@ export async function fillSegment(
   context: string,
   retries = 2
 ): Promise<string> {
-  const prompt = `${SYSTEM_PROMPT}\n\nContext:\n${context}\n\nCorrected text for the ">>" segment:`
+  const prompt = `${SYSTEM_PROMPT}\n\nContext:\n${context}\n\nJSON for the ">>" segment:`
 
   for (let attempt = 0; attempt <= retries; attempt++) {
     try {
@@ -139,11 +164,7 @@ export async function fillSegment(
         throw new Error(`claude exited ${exitCode}: ${stderr}`)
       }
 
-      const cleaned = stdout
-        .trim()
-        .replace(/^```(?:\w+)?\n?/, "")
-        .replace(/\n?```$/, "")
-        .trim()
+      const cleaned = extractFilledText(stdout)
 
       if (cleaned.length > 0) return cleaned
       throw new Error("empty response")
@@ -181,9 +202,12 @@ export async function fillFile(inputPath: string, outputPath: string): Promise<v
     const target = segments[idx]
     const context = buildContext(segments, idx)
     const corrected = await fillSegment(target, context)
-    if (corrected !== target.text) {
+    // Only count meaningful changes — ignore whitespace-only diffs (Whisper
+    // segments carry a leading space the model tends to drop).
+    if (corrected.trim() !== target.text.trim()) {
+      const leadingSpace = /^\s/.test(target.text) ? " " : ""
       target.original_text = target.text
-      target.text = corrected
+      target.text = leadingSpace + corrected
       target.gap_filled = true
       filledCount++
     }

--- a/tomasa/scripts/fill-transcript-gaps.ts
+++ b/tomasa/scripts/fill-transcript-gaps.ts
@@ -1,0 +1,219 @@
+#!/usr/bin/env bun
+/**
+ * Fill low-confidence / inaudible gaps in labeled Tomasa transcripts using Claude.
+ * Reads data/labeled-transcripts/, writes data/gap-filled-transcripts/.
+ *
+ * Usage: bun scripts/fill-transcript-gaps.ts
+ *   TOMASA_DATA_DIR overrides the data dir (needed when run from a git worktree).
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs"
+import { join } from "path"
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type Speaker = "Tomasa" | "Interviewer" | "unknown"
+
+export interface RawSegment {
+  id: number
+  seek: number
+  start: number
+  end: number
+  text: string
+  tokens: number[]
+  temperature: number
+  avg_logprob: number
+  compression_ratio: number
+  no_speech_prob: number
+}
+
+export interface LabeledSegment extends RawSegment {
+  speaker: Speaker
+}
+
+export interface GapSegment extends LabeledSegment {
+  gap_filled?: boolean
+  original_text?: string
+}
+
+// ─── Pure Helpers (exported for testing) ─────────────────────────────────────
+
+const LOGPROB_MIN = -0.5
+const NO_SPEECH_MAX = 0.6
+const COMPRESSION_MAX = 2.4
+const INAUDIBLE_RE = /\[inaudible\]/i
+
+/**
+ * Return the array indices of segments needing repair. A segment is flagged
+ * when any confidence metric is out of range or it contains a literal
+ * [inaudible] marker.
+ */
+export function flagSegments(segments: LabeledSegment[]): number[] {
+  const flagged: number[] = []
+  segments.forEach((s, i) => {
+    if (
+      s.avg_logprob < LOGPROB_MIN ||
+      s.no_speech_prob > NO_SPEECH_MAX ||
+      s.compression_ratio > COMPRESSION_MAX ||
+      INAUDIBLE_RE.test(s.text)
+    ) {
+      flagged.push(i)
+    }
+  })
+  return flagged
+}
+
+/**
+ * Build the context block passed to Claude: the `radius` segments before and
+ * after `index` (clamped to bounds), each as "<speaker>: <text>", with the
+ * target line prefixed ">> ".
+ */
+export function buildContext(
+  segments: LabeledSegment[],
+  index: number,
+  radius = 3
+): string {
+  const start = Math.max(0, index - radius)
+  const end = Math.min(segments.length - 1, index + radius)
+  const lines: string[] = []
+  for (let i = start; i <= end; i++) {
+    const s = segments[i]
+    const line = `${s.speaker}: ${s.text}`
+    lines.push(i === index ? `>> ${line}` : line)
+  }
+  return lines.join("\n")
+}
+
+// ─── Claude Fill ──────────────────────────────────────────────────────────────
+
+const CLAUDE_MODEL = "sonnet"
+
+const SYSTEM_PROMPT = `You are repairing a single segment of a Spanish-language oral history
+interview transcribed by ASR. Two speakers: "Tomasa" (grandmother, ~88, from Chihuahua,
+Mexico) and "Interviewer" (her grandson, Kristian).
+
+Some words are inaudible, mis-heard, or low-confidence. Using the surrounding context,
+return a corrected version of ONLY the marked segment (the line starting with ">>").
+
+Known names — use these spellings when the audio is ambiguous:
+- Family: Epifanio (father), Francisca (mother); siblings Evaristo, Paulina, Estefana, Lala;
+  husband Toño; children Miguel, Antonio, Arnulfo, Jesús, Tere; Marta;
+  grandchildren Kristian, Ericka, Alan, Aby.
+- Places: Rancho Los Olices, El Oro (a mine), Parral, Santa Bárbara, Chihuahua,
+  Estación Guichivo/Bahuichivo, Monterrey, Juárez.
+
+Chihuahua accent (shesheo) — apply sparingly, only if already hinted phonetically:
+muchacho→mushasho, chile→shile, ocho→osho, escúchame→escúshame.
+
+Rules:
+- Replace any [INAUDIBLE]/[inaudible] markers with the most plausible words from context.
+- Fix obvious mis-hearings of the known names/places above.
+- Keep Tomasa's natural voice; do not paraphrase or add content beyond the segment.
+- Return ONLY the corrected segment text. No quotes, no commentary, no markdown fences.`
+
+/**
+ * Ask Claude to correct a single flagged segment given its context.
+ * Fail-safe: returns the original text unchanged if every attempt fails.
+ */
+export async function fillSegment(
+  target: LabeledSegment,
+  context: string,
+  retries = 2
+): Promise<string> {
+  const prompt = `${SYSTEM_PROMPT}\n\nContext:\n${context}\n\nCorrected text for the ">>" segment:`
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const proc = Bun.spawn(["claude", "-p", "--model", CLAUDE_MODEL, prompt], {
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+
+      const [stdout, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        proc.exited,
+      ])
+
+      if (exitCode !== 0) {
+        const stderr = await new Response(proc.stderr).text()
+        throw new Error(`claude exited ${exitCode}: ${stderr}`)
+      }
+
+      const cleaned = stdout
+        .trim()
+        .replace(/^```(?:\w+)?\n?/, "")
+        .replace(/\n?```$/, "")
+        .trim()
+
+      if (cleaned.length > 0) return cleaned
+      throw new Error("empty response")
+    } catch (err) {
+      if (attempt < retries) {
+        await new Promise((r) => setTimeout(r, 1000 * Math.pow(2, attempt)))
+        continue
+      }
+      console.warn(`  ⚠ fill failed for segment id=${target.id}, keeping original`)
+      console.error("  Last error:", err)
+      return target.text
+    }
+  }
+  return target.text
+}
+
+// ─── File Processing ───────────────────────────────────────────────────────────
+
+export async function fillFile(inputPath: string, outputPath: string): Promise<void> {
+  const filename = inputPath.split("/").pop()!
+
+  if (existsSync(outputPath)) {
+    console.log(`✓ Already gap-filled: ${filename}`)
+    return
+  }
+
+  const raw = JSON.parse(readFileSync(inputPath, "utf-8"))
+  const segments: GapSegment[] = raw.segments ?? []
+  const flagged = flagSegments(segments)
+
+  console.log(`  ${filename}: ${segments.length} segments, ${flagged.length} flagged`)
+
+  let filledCount = 0
+  for (const idx of flagged) {
+    const target = segments[idx]
+    const context = buildContext(segments, idx)
+    const corrected = await fillSegment(target, context)
+    if (corrected !== target.text) {
+      target.original_text = target.text
+      target.text = corrected
+      target.gap_filled = true
+      filledCount++
+    }
+  }
+
+  writeFileSync(outputPath, JSON.stringify({ ...raw, segments }, null, 2))
+  console.log(`✓ ${filename}: ${filledCount} filled / ${flagged.length} flagged`)
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+if (import.meta.main) {
+  const DATA_DIR =
+    process.env.TOMASA_DATA_DIR ?? join(import.meta.dir, "..", "..", "data")
+  const INPUT_DIR = join(DATA_DIR, "labeled-transcripts")
+  const OUTPUT_DIR = join(DATA_DIR, "gap-filled-transcripts")
+
+  if (!existsSync(OUTPUT_DIR)) mkdirSync(OUTPUT_DIR, { recursive: true })
+
+  const FILES = [
+    "tomasa_2025-11-20_0805.json",
+    "tomasa_2025-11-20_1312.json",
+    "tomasa_2025-11-20_1336.json",
+  ]
+
+  console.log(`Gap-filling ${FILES.length} transcript(s)...\n`)
+
+  for (const f of FILES) {
+    await fillFile(join(INPUT_DIR, f), join(OUTPUT_DIR, f))
+  }
+
+  console.log("\nDone. Gap-filled files in:", OUTPUT_DIR)
+}


### PR DESCRIPTION
## Summary
- Adds `tomasa/scripts/fill-transcript-gaps.ts` — flags low-confidence Whisper segments (avg_logprob, no_speech_prob thresholds) and asks Claude to correct them in context
- Conservative prompt: only marks `gap_filled: true` when the correction meaningfully differs from the original text
- Includes spec + implementation plan docs, unit tests

Closes #5

## Test plan
- [x] Ran against all 3 Tomasa Nov-20 transcripts (`data/labeled-transcripts/tomasa_2025-11-20_{0805,1312,1336}.json`)
- [x] Output written to `data/gap-filled-transcripts/`
- [ ] Manual spot-check of flagged-but-unchanged segments in `0805` (9 flagged, 0 changed) to confirm conservative prompt isn't over-suppressing real fixes