### PR TITLE
feat(scripts): repeatable story-generation pipeline (transcript beats → narrative draft)

### DIFF
--- a/tomasa/docs/story-generation.md
+++ b/tomasa/docs/story-generation.md
@@ -21,6 +21,8 @@ pass/fail score
 
 ## Generating a draft
 
+Run these commands from the `tomasa/` subdirectory (e.g. `cd tomasa &&`).
+
 Two ways to select beats:
 
 **Explicit segment range** — when you already know where the story lives

--- a/tomasa/docs/story-generation.md
+++ b/tomasa/docs/story-generation.md
@@ -1,0 +1,103 @@
+# Story Generation Workflow
+
+How a labeled transcript becomes a narrative story draft, repeatably. This
+codifies the manual process used for the moon-landing draft (issue #10) so the
+remaining stories follow the same path.
+
+## Where this sits in the pipeline
+
+```
+data/labeled-transcripts/*.json        (transcribe-with-timestamps.ts + add-speaker-labels.ts)
+   │  generate-story.ts                (beat selection + Claude draft)
+   ▼
+apps/tomasa/src/content/drafts/<story>.md   (status: draft-v1)
+   │  human voice-check                (MANDATORY — see below)
+   ▼
+apps/tomasa/src/content/decades.ts     (manual integration as slides)
+   │  validate-content.ts
+   ▼
+pass/fail score
+```
+
+## Generating a draft
+
+Two ways to select beats:
+
+**Explicit segment range** — when you already know where the story lives
+(segment ids in the labeled transcript JSON):
+
+```bash
+bun scripts/generate-story.ts \
+  --transcript tomasa_2025-11-16_1704:395-428 \
+  --story moon-landing --title "La llegada a la luna" --decade 1960s
+```
+
+**Theme** — when the beats are scattered or unlocated; Claude scans the
+transcript(s) and selects matching passages:
+
+```bash
+bun scripts/generate-story.ts \
+  --transcript tomasa_2025-11-16_1704 --transcript tomasa_2025-11-20_0805 \
+  --theme "infancia pobre en el rancho en los años 30" \
+  --story poor-child --title "Una niña pobre" --decade 1930s
+```
+
+Multiple `--transcript` flags are allowed; each may carry its own
+`:<start>-<end>` range. Rangeless transcripts require `--theme`. Existing
+drafts are never overwritten without `--force`. `TOMASA_DATA_DIR` overrides
+the data directory (needed when running from a git worktree).
+
+## Output shape
+
+`apps/tomasa/src/content/drafts/<story>.md` with frontmatter citing exactly
+where the draft came from:
+
+```yaml
+---
+story: poor-child
+title: "Una niña pobre"
+decade: 1930s
+status: draft-v1
+generated: 2026-07-01
+sources:
+  - transcript: tomasa_2025-11-16_1704
+    segments: "395-428"
+emotional-spine: "Éramos tan felices que no sentíamos nada — dignidad en la pobreza"
+open-questions:
+  - "¿Qué edad tenía cuando volvieron al rancho El Oro?"
+voice-check: pending
+---
+```
+
+The body is the narrative draft: Spanish, first person, Tomasa's voice, built
+only from the cited beats. The drafting prompt forbids inventing events,
+names, places, dates, or feelings not present in the transcript.
+
+## Voice-check (required before decades.ts integration)
+
+A draft with `status: draft-v1` is **not publishable**. Before any content
+from it enters `decades.ts`:
+
+1. **Read the draft aloud with a Spanish speaker** — ideally a family member
+   who knew Tomasa's speech (Chihuahua register, shesheo). Listen for words or
+   constructions she would never use.
+2. **Check the emotional spine.** Does the `emotional-spine` line in the
+   frontmatter ring true to the person who was in the room for the interview?
+3. **Resolve every `open-questions` entry** with family before publication —
+   they mark facts the model found unclear or missing in the beats.
+4. **Spot-check against the source.** Use the `sources` citation to reread the
+   segments in `data/labeled-transcripts/` and confirm key phrases are hers.
+5. When it passes, set `voice-check: done` and `status: voice-checked` in the
+   frontmatter, then adapt the draft into `decades.ts` slides by hand
+   (data/format separation still applies — the draft file is source material,
+   not app content).
+
+## Remaining stories
+
+| Story | Decade | Status |
+| --- | --- | --- |
+| Moon landing | 1960s | draft-v1 (hand-written worked example) |
+| Poor child | 1930s | pending |
+| River accident | TBD | pending |
+| Moving to Chihuahua | 1940s | pending |
+| 5th story | TBD | pending |

--- a/tomasa/scripts/generate-story.test.ts
+++ b/tomasa/scripts/generate-story.test.ts
@@ -10,8 +10,8 @@ import {
   buildFrontmatter,
   extractDraft,
   extractSelectedIds,
-  type LabeledSegment,
 } from "./generate-story"
+import type { LabeledSegment } from "./generate-story"
 
 const seg = (over: Partial<LabeledSegment> = {}): LabeledSegment => ({
   id: 0,
@@ -213,6 +213,10 @@ describe("formatBeats", () => {
 describe("yamlQuote", () => {
   it("escapes quotes and backslashes", () => {
     expect(yamlQuote('dijo "mijo" \\ ya')).toBe('"dijo \\"mijo\\" \\\\ ya"')
+  })
+
+  it("escapes newlines, carriage returns, and tabs", () => {
+    expect(yamlQuote("linea1\nlinea2\r\ttab")).toBe('"linea1\\nlinea2\\r\\ttab"')
   })
 })
 

--- a/tomasa/scripts/generate-story.test.ts
+++ b/tomasa/scripts/generate-story.test.ts
@@ -49,6 +49,17 @@ describe("parseTranscriptSpec", () => {
   it("rejects an inverted range", () => {
     expect(() => parseTranscriptSpec("foo:428-395")).toThrow("start 428 > end 395")
   })
+
+  it.each([
+    ["../secrets"],
+    ["../secrets:1-5"],
+    ["a/b"],
+    ["a\\b:1-5"],
+    ["..:1-5"],
+    ["."],
+  ])("rejects path-like transcript name %s", (spec) => {
+    expect(() => parseTranscriptSpec(spec)).toThrow(/Invalid/)
+  })
 })
 
 describe("parseStoryArgs", () => {
@@ -127,6 +138,14 @@ describe("parseStoryArgs", () => {
   it("rejects unknown flags", () => {
     expect(() => parseStoryArgs([...base, "--bogus"])).toThrow("Unknown argument")
   })
+
+  it.each([["../decades"], ["a/b"], ["Poor-Child"], ["poor child"], ["poor--child"], ["poor-child-"]])(
+    "rejects non-kebab-case / path-like --story %s",
+    (story) => {
+      const argv = base.map((v, i) => (base[i - 1] === "--story" ? story : v))
+      expect(() => parseStoryArgs(argv)).toThrow('Invalid --story')
+    }
+  )
 })
 
 describe("selectByRange", () => {

--- a/tomasa/scripts/generate-story.test.ts
+++ b/tomasa/scripts/generate-story.test.ts
@@ -146,6 +146,14 @@ describe("parseStoryArgs", () => {
       expect(() => parseStoryArgs(argv)).toThrow('Invalid --story')
     }
   )
+
+  it.each([["1930"], ["1930S"], ["thirties"], ["1930s\nfoo:"], ["1930s:"]])(
+    "rejects a malformed --decade %s",
+    (decade) => {
+      const argv = base.map((v, i) => (base[i - 1] === "--decade" ? decade : v))
+      expect(() => parseStoryArgs(argv)).toThrow("Invalid --decade")
+    }
+  )
 })
 
 describe("selectByRange", () => {

--- a/tomasa/scripts/generate-story.test.ts
+++ b/tomasa/scripts/generate-story.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect } from "bun:test"
+import {
+  parseTranscriptSpec,
+  parseStoryArgs,
+  selectByRange,
+  groupIntoRuns,
+  formatRuns,
+  formatBeats,
+  yamlQuote,
+  buildFrontmatter,
+  extractDraft,
+  extractSelectedIds,
+  type LabeledSegment,
+} from "./generate-story"
+
+const seg = (over: Partial<LabeledSegment> = {}): LabeledSegment => ({
+  id: 0,
+  seek: 0,
+  start: 0,
+  end: 1,
+  text: " hola",
+  tokens: [],
+  temperature: 0,
+  avg_logprob: -0.3,
+  compression_ratio: 1.5,
+  no_speech_prob: 0.1,
+  speaker: "Tomasa",
+  ...over,
+})
+
+describe("parseTranscriptSpec", () => {
+  it("parses a bare name", () => {
+    expect(parseTranscriptSpec("tomasa_2025-11-16_1704")).toEqual({
+      name: "tomasa_2025-11-16_1704",
+    })
+  })
+
+  it("parses a name with a segment range", () => {
+    expect(parseTranscriptSpec("tomasa_2025-11-16_1704:395-428")).toEqual({
+      name: "tomasa_2025-11-16_1704",
+      range: { start: 395, end: 428 },
+    })
+  })
+
+  it("rejects a malformed range", () => {
+    expect(() => parseTranscriptSpec("foo:395-")).toThrow("Invalid --transcript spec")
+  })
+
+  it("rejects an inverted range", () => {
+    expect(() => parseTranscriptSpec("foo:428-395")).toThrow("start 428 > end 395")
+  })
+})
+
+describe("parseStoryArgs", () => {
+  const base = [
+    "--transcript",
+    "tomasa_2025-11-16_1704:395-428",
+    "--story",
+    "poor-child",
+    "--title",
+    "Una niña pobre",
+    "--decade",
+    "1930s",
+  ]
+
+  it("parses a full range-mode invocation", () => {
+    const args = parseStoryArgs(base)
+    expect(args.story).toBe("poor-child")
+    expect(args.title).toBe("Una niña pobre")
+    expect(args.decade).toBe("1930s")
+    expect(args.force).toBe(false)
+    expect(args.transcripts).toHaveLength(1)
+    expect(args.transcripts[0].range).toEqual({ start: 395, end: 428 })
+  })
+
+  it("accepts multiple transcripts and --force", () => {
+    const args = parseStoryArgs([
+      ...base,
+      "--transcript",
+      "tomasa_2025-11-20_0805:10-40",
+      "--force",
+    ])
+    expect(args.transcripts).toHaveLength(2)
+    expect(args.force).toBe(true)
+  })
+
+  it("allows a rangeless transcript when --theme is given", () => {
+    const args = parseStoryArgs([
+      "--transcript",
+      "tomasa_2025-11-16_1704",
+      "--theme",
+      "niña pobre",
+      "--story",
+      "poor-child",
+      "--title",
+      "Una niña pobre",
+      "--decade",
+      "1930s",
+    ])
+    expect(args.theme).toBe("niña pobre")
+    expect(args.transcripts[0].range).toBeUndefined()
+  })
+
+  it("rejects a rangeless transcript without --theme", () => {
+    expect(() =>
+      parseStoryArgs([
+        "--transcript",
+        "tomasa_2025-11-16_1704",
+        "--story",
+        "x",
+        "--title",
+        "X",
+        "--decade",
+        "1930s",
+      ])
+    ).toThrow("No beat selection")
+  })
+
+  it.each([["--story"], ["--title"], ["--decade"]])(
+    "rejects when %s is missing",
+    (flag) => {
+      const argv = base.filter((_, i) => base[i] !== flag && base[i - 1] !== flag)
+      expect(() => parseStoryArgs(argv)).toThrow(`${flag} is required`)
+    }
+  )
+
+  it("rejects unknown flags", () => {
+    expect(() => parseStoryArgs([...base, "--bogus"])).toThrow("Unknown argument")
+  })
+})
+
+describe("selectByRange", () => {
+  const segs = Array.from({ length: 10 }, (_, i) => seg({ id: i }))
+
+  it("returns segments inside the inclusive range", () => {
+    const out = selectByRange(segs, { start: 3, end: 5 })
+    expect(out.map((s) => s.id)).toEqual([3, 4, 5])
+  })
+
+  it("returns empty for a range outside the transcript", () => {
+    expect(selectByRange(segs, { start: 100, end: 200 })).toEqual([])
+  })
+})
+
+describe("groupIntoRuns", () => {
+  it("returns empty for no ids", () => {
+    expect(groupIntoRuns([])).toEqual([])
+  })
+
+  it("groups contiguous ids into one run", () => {
+    expect(groupIntoRuns([3, 4, 5])).toEqual([{ start: 3, end: 5 }])
+  })
+
+  it("bridges gaps within the tolerance", () => {
+    // gap of 2 (ids 5,6 missing) is bridged with default tolerance 2
+    expect(groupIntoRuns([3, 4, 7])).toEqual([{ start: 3, end: 7 }])
+  })
+
+  it("splits runs when the gap exceeds the tolerance", () => {
+    expect(groupIntoRuns([3, 4, 8])).toEqual([
+      { start: 3, end: 4 },
+      { start: 8, end: 8 },
+    ])
+  })
+
+  it("sorts and deduplicates ids", () => {
+    expect(groupIntoRuns([5, 3, 4, 4])).toEqual([{ start: 3, end: 5 }])
+  })
+})
+
+describe("formatRuns", () => {
+  it("formats ranges and collapses single-segment runs", () => {
+    expect(
+      formatRuns([
+        { start: 12, end: 40 },
+        { start: 88, end: 88 },
+      ])
+    ).toBe("12-40, 88")
+  })
+})
+
+describe("formatBeats", () => {
+  it("emits one trimmed line per beat", () => {
+    const beats = [
+      seg({ id: 1, speaker: "Interviewer", text: " ¿Y el rancho? " }),
+      seg({ id: 2, text: " Éramos felices. " }),
+    ]
+    expect(formatBeats(beats)).toBe(
+      "1 | Interviewer | ¿Y el rancho?\n2 | Tomasa | Éramos felices."
+    )
+  })
+})
+
+describe("yamlQuote", () => {
+  it("escapes quotes and backslashes", () => {
+    expect(yamlQuote('dijo "mijo" \\ ya')).toBe('"dijo \\"mijo\\" \\\\ ya"')
+  })
+})
+
+describe("buildFrontmatter", () => {
+  const meta = {
+    story: "poor-child",
+    title: "Una niña pobre",
+    decade: "1930s",
+    generated: "2026-07-01",
+  }
+  const sources = [{ transcript: "tomasa_2025-11-16_1704", segments: "395-428" }]
+
+  it("emits the full draft-v1 shape with sources and open questions", () => {
+    const fm = buildFrontmatter(meta, sources, "La dignidad en la pobreza", [
+      "¿Qué edad tenía exactamente?",
+    ])
+    expect(fm).toBe(
+      [
+        "---",
+        "story: poor-child",
+        'title: "Una niña pobre"',
+        "decade: 1930s",
+        "status: draft-v1",
+        "generated: 2026-07-01",
+        "sources:",
+        "  - transcript: tomasa_2025-11-16_1704",
+        '    segments: "395-428"',
+        'emotional-spine: "La dignidad en la pobreza"',
+        "open-questions:",
+        '  - "¿Qué edad tenía exactamente?"',
+        "voice-check: pending",
+        "---",
+      ].join("\n")
+    )
+  })
+
+  it("emits an empty list when there are no open questions", () => {
+    const fm = buildFrontmatter(meta, sources, "spine", [])
+    expect(fm).toContain("open-questions: []")
+  })
+})
+
+describe("extractDraft", () => {
+  const valid = JSON.stringify({
+    body: "Nosotros en el rancho...",
+    emotionalSpine: "Felicidad sin nada",
+    openQuestions: ["¿Qué año?"],
+  })
+
+  it("parses a plain JSON response", () => {
+    const draft = extractDraft(valid)
+    expect(draft.body).toBe("Nosotros en el rancho...")
+    expect(draft.emotionalSpine).toBe("Felicidad sin nada")
+    expect(draft.openQuestions).toEqual(["¿Qué año?"])
+  })
+
+  it("strips markdown fences with CRLF and uppercase tags", () => {
+    const draft = extractDraft("```JSON\r\n" + valid + "\r\n```")
+    expect(draft.body).toBe("Nosotros en el rancho...")
+  })
+
+  it("defaults openQuestions to [] and drops non-strings", () => {
+    const draft = extractDraft(
+      JSON.stringify({ body: "x", emotionalSpine: "y", openQuestions: [1, "ok"] })
+    )
+    expect(draft.openQuestions).toEqual(["ok"])
+    expect(
+      extractDraft(JSON.stringify({ body: "x", emotionalSpine: "y" })).openQuestions
+    ).toEqual([])
+  })
+
+  it("throws when body is missing or empty", () => {
+    expect(() => extractDraft(JSON.stringify({ emotionalSpine: "y" }))).toThrow("body")
+    expect(() =>
+      extractDraft(JSON.stringify({ body: "  ", emotionalSpine: "y" }))
+    ).toThrow("body")
+  })
+
+  it("throws when emotionalSpine is missing", () => {
+    expect(() => extractDraft(JSON.stringify({ body: "x" }))).toThrow("emotionalSpine")
+  })
+})
+
+describe("extractSelectedIds", () => {
+  it("parses a plain id array", () => {
+    expect(extractSelectedIds("[395, 396, 397]")).toEqual([395, 396, 397])
+  })
+
+  it("strips fences and drops non-integer entries", () => {
+    expect(extractSelectedIds('```json\n[1, "2", 3.5, 4]\n```')).toEqual([1, 4])
+  })
+
+  it("throws on a non-array response", () => {
+    expect(() => extractSelectedIds('{"ids": [1]}')).toThrow("not a JSON array")
+  })
+})

--- a/tomasa/scripts/generate-story.ts
+++ b/tomasa/scripts/generate-story.ts
@@ -231,9 +231,14 @@ export function formatBeats(beats: LabeledSegment[]): string {
   return beats.map((s) => `${s.id} | ${s.speaker} | ${s.text.trim()}`).join("\n")
 }
 
-/** Double-quoted YAML scalar with backslash and quote escaping. */
+/** Double-quoted YAML scalar with backslash, quote, and control-char escaping. */
 export function yamlQuote(value: string): string {
-  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`
+  return `"${value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t")}"`
 }
 
 /**

--- a/tomasa/scripts/generate-story.ts
+++ b/tomasa/scripts/generate-story.ts
@@ -327,7 +327,16 @@ export function extractSelectedIds(raw: string): number[] {
 const CLAUDE_MODEL = "sonnet"
 const SELECT_CHUNK_SIZE = 120
 
-async function runClaude(prompt: string, retries = 2): Promise<string> {
+/**
+ * Run the claude subprocess and parse its output with `parse`. Retries on
+ * both subprocess failure AND parse failure — a malformed/fenced response is
+ * usually transient, same as fill-transcript-gaps.ts / add-speaker-labels.ts.
+ */
+async function runClaude<T>(
+  prompt: string,
+  parse: (raw: string) => T,
+  retries = 2
+): Promise<T> {
   let lastErr: unknown
   for (let attempt = 0; attempt <= retries; attempt++) {
     try {
@@ -345,7 +354,7 @@ async function runClaude(prompt: string, retries = 2): Promise<string> {
         const stderr = await new Response(proc.stderr).text()
         throw new Error(`claude exited ${exitCode}: ${stderr}`)
       }
-      return stdout
+      return parse(stdout)
     } catch (err) {
       lastErr = err
       if (attempt < retries) {
@@ -385,7 +394,7 @@ async function selectBeatsByTheme(
     process.stdout.write(`    ${name}: selecting beats, chunk ${i + 1}/${chunks.length}...`)
     const prompt = `${SELECT_SYSTEM_PROMPT}\n\nTheme: ${theme}\n\nSegments:\n${JSON.stringify(chunks[i])}`
     try {
-      const ids = extractSelectedIds(await runClaude(prompt))
+      const ids = await runClaude(prompt, extractSelectedIds)
       selected.push(...ids)
       process.stdout.write(` ✓ (${ids.length})\n`)
     } catch (err) {
@@ -439,8 +448,7 @@ async function draftStory(
     `${DRAFT_SYSTEM_PROMPT}\n\nStory: ${args.title} (decade: ${args.decade})${themeLine}` +
     `\n\nInterview beats (id | speaker | text):\n${beatsBlock}\n\nJSON draft:`
 
-  const raw = await runClaude(prompt)
-  return extractDraft(raw)
+  return runClaude(prompt, extractDraft)
 }
 
 // ─── Main ────────────────────────────────────────────────────────────────────

--- a/tomasa/scripts/generate-story.ts
+++ b/tomasa/scripts/generate-story.ts
@@ -83,6 +83,8 @@ export interface StoryDraft {
 // Both values end up in filesystem paths — reject separators, dots, "..".
 const TRANSCRIPT_NAME_RE = /^[A-Za-z0-9_-]+$/
 const STORY_ID_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/
+// --decade lands unquoted in YAML frontmatter — restrict its shape to prevent injection.
+const DECADE_RE = /^\d{4}s$/
 
 /**
  * Parse a --transcript value: "<name>" or "<name>:<start>-<end>".
@@ -173,6 +175,9 @@ export function parseStoryArgs(argv: string[]): StoryArgs {
   }
   if (!title) throw new Error("--title is required")
   if (!decade) throw new Error("--decade is required (e.g. 1930s)")
+  if (!DECADE_RE.test(decade)) {
+    throw new Error(`Invalid --decade "${decade}" — must match "<4 digits>s", e.g. 1930s`)
+  }
 
   const missingRange = transcripts.filter((t) => !t.range)
   if (missingRange.length > 0 && !theme) {
@@ -384,8 +389,11 @@ async function selectBeatsByTheme(
       selected.push(...ids)
       process.stdout.write(` ✓ (${ids.length})\n`)
     } catch (err) {
-      process.stdout.write(" ⚠ skipped\n")
-      console.error("    Last error:", err)
+      process.stdout.write(" ✗ failed\n")
+      throw new Error(
+        `${name}: beat selection failed on chunk ${i + 1}/${chunks.length} after retries`,
+        { cause: err }
+      )
     }
   }
 

--- a/tomasa/scripts/generate-story.ts
+++ b/tomasa/scripts/generate-story.ts
@@ -1,0 +1,499 @@
+#!/usr/bin/env bun
+/**
+ * Generate a narrative story draft from labeled transcript beats using Claude.
+ * Codifies the manual process used for the moon-landing draft (issue #10).
+ *
+ * Reads data/labeled-transcripts/, writes apps/tomasa/src/content/drafts/<story>.md
+ * with frontmatter citing the source transcript(s) and segment range(s).
+ *
+ * Usage (explicit segment range):
+ *   bun scripts/generate-story.ts \
+ *     --transcript tomasa_2025-11-16_1704:395-428 \
+ *     --story moon-landing --title "La llegada a la luna" --decade 1960s
+ *
+ * Usage (theme-based beat selection across transcripts):
+ *   bun scripts/generate-story.ts \
+ *     --transcript tomasa_2025-11-16_1704 --transcript tomasa_2025-11-20_0805 \
+ *     --theme "infancia pobre en el rancho en los años 30" \
+ *     --story poor-child --title "Una niña pobre" --decade 1930s
+ *
+ *   TOMASA_DATA_DIR overrides the data dir (needed when run from a git worktree).
+ *
+ * See docs/story-generation.md for the full workflow — including the mandatory
+ * human voice-check (read aloud with a Spanish speaker) before a draft is
+ * integrated into decades.ts.
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs"
+import { join } from "path"
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type Speaker = "Tomasa" | "Interviewer" | "unknown"
+
+export interface RawSegment {
+  id: number
+  seek: number
+  start: number
+  end: number
+  text: string
+  tokens: number[]
+  temperature: number
+  avg_logprob: number
+  compression_ratio: number
+  no_speech_prob: number
+}
+
+export interface LabeledSegment extends RawSegment {
+  speaker: Speaker
+}
+
+export interface SegmentRange {
+  start: number
+  end: number
+}
+
+export interface TranscriptSpec {
+  name: string
+  range?: SegmentRange
+}
+
+export interface StoryArgs {
+  transcripts: TranscriptSpec[]
+  theme?: string
+  story: string
+  title: string
+  decade: string
+  force: boolean
+}
+
+export interface SourceCitation {
+  transcript: string
+  segments: string
+}
+
+export interface StoryDraft {
+  body: string
+  emotionalSpine: string
+  openQuestions: string[]
+}
+
+// ─── Pure Helpers (exported for testing) ─────────────────────────────────────
+
+/**
+ * Parse a --transcript value: "<name>" or "<name>:<start>-<end>".
+ * The range is a segment-id range within that transcript, inclusive.
+ */
+export function parseTranscriptSpec(spec: string): TranscriptSpec {
+  const colon = spec.lastIndexOf(":")
+  if (colon === -1) return { name: spec }
+
+  const name = spec.slice(0, colon)
+  const rangePart = spec.slice(colon + 1)
+  const match = rangePart.match(/^(\d+)-(\d+)$/)
+  if (!name || !match) {
+    throw new Error(
+      `Invalid --transcript spec "${spec}" — expected "<name>" or "<name>:<start>-<end>"`
+    )
+  }
+
+  const start = Number(match[1])
+  const end = Number(match[2])
+  if (start > end) {
+    throw new Error(`Invalid range in "${spec}" — start ${start} > end ${end}`)
+  }
+  return { name, range: { start, end } }
+}
+
+/**
+ * Parse CLI args. Requires --story, --title, --decade, and at least one
+ * --transcript. Every transcript must carry a range unless --theme is given.
+ */
+export function parseStoryArgs(argv: string[]): StoryArgs {
+  const transcripts: TranscriptSpec[] = []
+  let theme: string | undefined
+  let story = ""
+  let title = ""
+  let decade = ""
+  let force = false
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    const next = () => {
+      const v = argv[++i]
+      if (v === undefined) throw new Error(`Missing value for ${arg}`)
+      return v
+    }
+    switch (arg) {
+      case "--transcript":
+        transcripts.push(parseTranscriptSpec(next()))
+        break
+      case "--theme":
+        theme = next()
+        break
+      case "--story":
+        story = next()
+        break
+      case "--title":
+        title = next()
+        break
+      case "--decade":
+        decade = next()
+        break
+      case "--force":
+        force = true
+        break
+      default:
+        throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  if (transcripts.length === 0) throw new Error("At least one --transcript is required")
+  if (!story) throw new Error("--story is required (kebab-case id, e.g. poor-child)")
+  if (!title) throw new Error("--title is required")
+  if (!decade) throw new Error("--decade is required (e.g. 1930s)")
+
+  const missingRange = transcripts.filter((t) => !t.range)
+  if (missingRange.length > 0 && !theme) {
+    throw new Error(
+      `No beat selection for ${missingRange.map((t) => t.name).join(", ")} — ` +
+        "give each transcript a :<start>-<end> range or pass --theme"
+    )
+  }
+
+  return { transcripts, theme, story, title, decade, force }
+}
+
+/** Segments whose id falls inside the inclusive range. */
+export function selectByRange(
+  segments: LabeledSegment[],
+  range: SegmentRange
+): LabeledSegment[] {
+  return segments.filter((s) => s.id >= range.start && s.id <= range.end)
+}
+
+/**
+ * Collapse a set of segment ids into sorted contiguous ranges. Gaps of up to
+ * `gapTolerance` ids are bridged so short interviewer interjections between
+ * selected beats do not split a run.
+ */
+export function groupIntoRuns(ids: number[], gapTolerance = 2): SegmentRange[] {
+  if (ids.length === 0) return []
+
+  const sorted = [...new Set(ids)].sort((a, b) => a - b)
+  const runs: SegmentRange[] = []
+  let start = sorted[0]
+  let end = sorted[0]
+
+  for (const id of sorted.slice(1)) {
+    if (id - end <= gapTolerance + 1) {
+      end = id
+    } else {
+      runs.push({ start, end })
+      start = id
+      end = id
+    }
+  }
+  runs.push({ start, end })
+  return runs
+}
+
+/** "12-40, 88-102" — single-segment runs collapse to one number. */
+export function formatRuns(runs: SegmentRange[]): string {
+  return runs
+    .map((r) => (r.start === r.end ? `${r.start}` : `${r.start}-${r.end}`))
+    .join(", ")
+}
+
+/** One beat per line: "<id> | <speaker> | <text>". */
+export function formatBeats(beats: LabeledSegment[]): string {
+  return beats.map((s) => `${s.id} | ${s.speaker} | ${s.text.trim()}`).join("\n")
+}
+
+/** Double-quoted YAML scalar with backslash and quote escaping. */
+export function yamlQuote(value: string): string {
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`
+}
+
+/**
+ * Build the draft frontmatter. Shape matches the hand-written moon-landing.md
+ * worked example described in issue #10: story, decade, sources (transcript +
+ * segment range), emotional-spine, open-questions, status draft-v1.
+ */
+export function buildFrontmatter(
+  meta: { story: string; title: string; decade: string; generated: string },
+  sources: SourceCitation[],
+  emotionalSpine: string,
+  openQuestions: string[]
+): string {
+  const lines = [
+    "---",
+    `story: ${meta.story}`,
+    `title: ${yamlQuote(meta.title)}`,
+    `decade: ${meta.decade}`,
+    "status: draft-v1",
+    `generated: ${meta.generated}`,
+    "sources:",
+    ...sources.flatMap((s) => [
+      `  - transcript: ${s.transcript}`,
+      `    segments: ${yamlQuote(s.segments)}`,
+    ]),
+    `emotional-spine: ${yamlQuote(emotionalSpine)}`,
+  ]
+
+  if (openQuestions.length === 0) {
+    lines.push("open-questions: []")
+  } else {
+    lines.push("open-questions:")
+    for (const q of openQuestions) lines.push(`  - ${yamlQuote(q)}`)
+  }
+
+  lines.push("voice-check: pending", "---")
+  return lines.join("\n")
+}
+
+/** Strip optional markdown fences (CRLF- and case-tolerant) and parse JSON. */
+export function extractJson(raw: string): unknown {
+  const stripped = raw
+    .trim()
+    .replace(/^```(?:json)?\r?\n?/i, "")
+    .replace(/\r?\n?```$/, "")
+    .trim()
+  return JSON.parse(stripped)
+}
+
+/**
+ * Parse Claude's draft response: {"body", "emotionalSpine", "openQuestions"}.
+ * Throws if body or emotionalSpine is missing — the caller retries.
+ */
+export function extractDraft(raw: string): StoryDraft {
+  const parsed = extractJson(raw) as Partial<StoryDraft>
+  if (typeof parsed?.body !== "string" || parsed.body.trim().length === 0) {
+    throw new Error("response missing non-empty string 'body' field")
+  }
+  if (typeof parsed?.emotionalSpine !== "string") {
+    throw new Error("response missing string 'emotionalSpine' field")
+  }
+  const openQuestions = Array.isArray(parsed.openQuestions)
+    ? parsed.openQuestions.filter((q): q is string => typeof q === "string")
+    : []
+  return {
+    body: parsed.body.trim(),
+    emotionalSpine: parsed.emotionalSpine.trim(),
+    openQuestions,
+  }
+}
+
+/** Parse Claude's beat-selection response: a JSON array of segment ids. */
+export function extractSelectedIds(raw: string): number[] {
+  const parsed = extractJson(raw)
+  if (!Array.isArray(parsed)) throw new Error("response is not a JSON array")
+  return parsed.filter((id): id is number => Number.isInteger(id))
+}
+
+// ─── Claude Subprocess ────────────────────────────────────────────────────────
+
+const CLAUDE_MODEL = "sonnet"
+const SELECT_CHUNK_SIZE = 120
+
+async function runClaude(prompt: string, retries = 2): Promise<string> {
+  let lastErr: unknown
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const proc = Bun.spawn(["claude", "-p", "--model", CLAUDE_MODEL, prompt], {
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+
+      const [stdout, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        proc.exited,
+      ])
+
+      if (exitCode !== 0) {
+        const stderr = await new Response(proc.stderr).text()
+        throw new Error(`claude exited ${exitCode}: ${stderr}`)
+      }
+      return stdout
+    } catch (err) {
+      lastErr = err
+      if (attempt < retries) {
+        await new Promise((r) => setTimeout(r, 1000 * Math.pow(2, attempt)))
+      }
+    }
+  }
+  throw lastErr
+}
+
+// ─── Beat Selection (theme mode) ──────────────────────────────────────────────
+
+const SELECT_SYSTEM_PROMPT = `You are selecting segments from a Spanish-language oral history
+interview with Tomasa, an elderly Mexican grandmother from Chihuahua. Two speakers:
+"Tomasa" (long narratives about her past) and "Interviewer" (her grandson, short questions).
+
+Given a theme and a list of segments, return the ids of segments that belong to that theme —
+Tomasa's tellings of it plus the interviewer questions that prompted them. Prefer complete
+narrative passages over isolated mentions. If nothing matches, return [].
+
+Respond with ONLY a JSON array of segment id numbers, e.g. [395, 396, 397].
+No extra text, no markdown fences.`
+
+async function selectBeatsByTheme(
+  name: string,
+  segments: LabeledSegment[],
+  theme: string
+): Promise<LabeledSegment[]> {
+  const minSegs = segments.map((s) => ({ id: s.id, speaker: s.speaker, text: s.text }))
+  const chunks: (typeof minSegs)[] = []
+  for (let i = 0; i < minSegs.length; i += SELECT_CHUNK_SIZE) {
+    chunks.push(minSegs.slice(i, i + SELECT_CHUNK_SIZE))
+  }
+
+  const selected: number[] = []
+  for (let i = 0; i < chunks.length; i++) {
+    process.stdout.write(`    ${name}: selecting beats, chunk ${i + 1}/${chunks.length}...`)
+    const prompt = `${SELECT_SYSTEM_PROMPT}\n\nTheme: ${theme}\n\nSegments:\n${JSON.stringify(chunks[i])}`
+    try {
+      const ids = extractSelectedIds(await runClaude(prompt))
+      selected.push(...ids)
+      process.stdout.write(` ✓ (${ids.length})\n`)
+    } catch (err) {
+      process.stdout.write(" ⚠ skipped\n")
+      console.error("    Last error:", err)
+    }
+  }
+
+  const runs = groupIntoRuns(selected)
+  const inRuns = new Set<number>()
+  for (const seg of segments) {
+    if (runs.some((r) => seg.id >= r.start && seg.id <= r.end)) inRuns.add(seg.id)
+  }
+  return segments.filter((s) => inRuns.has(s.id))
+}
+
+// ─── Story Drafting ───────────────────────────────────────────────────────────
+
+const DRAFT_SYSTEM_PROMPT = `You are drafting a short narrative story for a memorial website about
+Tomasa, a Mexican grandmother from rural Chihuahua, built ONLY from the interview beats
+provided — her own words from oral history recordings, transcribed by ASR.
+
+Rules:
+- Write in Spanish, first person, in Tomasa's voice.
+- Preserve her actual phrasing wherever possible. You may lightly smooth ASR noise and
+  connect beats, but NEVER invent events, names, places, dates, or feelings that are not
+  in the beats. Inventing content corrupts the family record.
+- Keep her rural Chihuahua register when it appears in the beats ("mijo", "fíjate", "pos").
+- Ignore beats that are clearly off-topic for the requested story.
+- Structure: 3–6 short paragraphs with a clear emotional arc — the story must have one
+  emotional spine, a single feeling or tension that holds it together.
+- List open questions: facts that are unclear, contradictory, or missing from the beats
+  that a family member should verify before publication.
+
+Respond with ONLY a JSON object, no markdown fences, no commentary:
+{
+  "body": "<the story draft in markdown, paragraphs separated by blank lines>",
+  "emotionalSpine": "<one sentence naming the feeling/tension that carries the story>",
+  "openQuestions": ["<question a family member should verify>", ...]
+}`
+
+async function draftStory(
+  beatsBlock: string,
+  args: StoryArgs
+): Promise<StoryDraft> {
+  const themeLine = args.theme ? `\nTheme: ${args.theme}` : ""
+  const prompt =
+    `${DRAFT_SYSTEM_PROMPT}\n\nStory: ${args.title} (decade: ${args.decade})${themeLine}` +
+    `\n\nInterview beats (id | speaker | text):\n${beatsBlock}\n\nJSON draft:`
+
+  const raw = await runClaude(prompt)
+  return extractDraft(raw)
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+const USAGE = `Usage:
+  bun scripts/generate-story.ts \\
+    --transcript <name>[:<start>-<end>] [--transcript ...] \\
+    [--theme "<beat selection theme>"] \\
+    --story <kebab-id> --title "<title>" --decade <1930s> [--force]`
+
+if (import.meta.main) {
+  let args: StoryArgs
+  try {
+    args = parseStoryArgs(process.argv.slice(2))
+  } catch (err) {
+    console.error(`✗ ${err instanceof Error ? err.message : err}\n\n${USAGE}`)
+    process.exit(1)
+  }
+
+  const TOMASA_DIR = join(import.meta.dir, "..")
+  const DATA_DIR = process.env.TOMASA_DATA_DIR ?? join(TOMASA_DIR, "..", "data")
+  const LABELED_DIR = join(DATA_DIR, "labeled-transcripts")
+  const DRAFTS_DIR = join(TOMASA_DIR, "apps", "tomasa", "src", "content", "drafts")
+  const outputPath = join(DRAFTS_DIR, `${args.story}.md`)
+
+  if (existsSync(outputPath) && !args.force) {
+    console.log(`✓ Draft already exists: ${outputPath}`)
+    console.log("  Use --force to regenerate (overwrites the existing draft).")
+    process.exit(0)
+  }
+
+  const sources: SourceCitation[] = []
+  const beatBlocks: string[] = []
+  let totalBeats = 0
+
+  for (const spec of args.transcripts) {
+    const inputPath = join(LABELED_DIR, `${spec.name}.json`)
+    if (!existsSync(inputPath)) {
+      console.error(`✗ Labeled transcript not found: ${inputPath}`)
+      console.error("  Run scripts/add-speaker-labels.ts first, or check TOMASA_DATA_DIR.")
+      process.exit(1)
+    }
+
+    const raw = JSON.parse(readFileSync(inputPath, "utf-8"))
+    const segments: LabeledSegment[] = raw.segments ?? []
+
+    const beats = spec.range
+      ? selectByRange(segments, spec.range)
+      : await selectBeatsByTheme(spec.name, segments, args.theme!)
+
+    if (beats.length === 0) {
+      console.warn(`  ⚠ ${spec.name}: no beats selected, skipping`)
+      continue
+    }
+
+    const runs = groupIntoRuns(beats.map((s) => s.id))
+    sources.push({ transcript: spec.name, segments: formatRuns(runs) })
+    beatBlocks.push(`[${spec.name}]\n${formatBeats(beats)}`)
+    totalBeats += beats.length
+    console.log(`  ${spec.name}: ${beats.length} beats (segments ${formatRuns(runs)})`)
+  }
+
+  if (totalBeats === 0) {
+    console.error("✗ No beats selected from any transcript — nothing to draft.")
+    process.exit(1)
+  }
+
+  console.log(`\nDrafting "${args.title}" from ${totalBeats} beats...`)
+  const draft = await draftStory(beatBlocks.join("\n\n"), args)
+
+  const generated = new Date().toISOString().slice(0, 10)
+  const frontmatter = buildFrontmatter(
+    { story: args.story, title: args.title, decade: args.decade, generated },
+    sources,
+    draft.emotionalSpine,
+    draft.openQuestions
+  )
+
+  if (!existsSync(DRAFTS_DIR)) mkdirSync(DRAFTS_DIR, { recursive: true })
+  writeFileSync(outputPath, `${frontmatter}\n\n${draft.body}\n`)
+
+  console.log(`\n✓ Draft written: ${outputPath}`)
+  if (draft.openQuestions.length > 0) {
+    console.log(`  Open questions to verify with family: ${draft.openQuestions.length}`)
+  }
+  console.log(
+    "\nNext step (required before decades.ts integration): voice-check —\n" +
+      "read the draft aloud with a Spanish speaker. See docs/story-generation.md."
+  )
+}

--- a/tomasa/scripts/generate-story.ts
+++ b/tomasa/scripts/generate-story.ts
@@ -80,13 +80,24 @@ export interface StoryDraft {
 
 // ─── Pure Helpers (exported for testing) ─────────────────────────────────────
 
+// Both values end up in filesystem paths — reject separators, dots, "..".
+const TRANSCRIPT_NAME_RE = /^[A-Za-z0-9_-]+$/
+const STORY_ID_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/
+
 /**
  * Parse a --transcript value: "<name>" or "<name>:<start>-<end>".
  * The range is a segment-id range within that transcript, inclusive.
  */
 export function parseTranscriptSpec(spec: string): TranscriptSpec {
   const colon = spec.lastIndexOf(":")
-  if (colon === -1) return { name: spec }
+  if (colon === -1) {
+    if (!TRANSCRIPT_NAME_RE.test(spec)) {
+      throw new Error(
+        `Invalid transcript name "${spec}" — only letters, digits, "_" and "-" are allowed`
+      )
+    }
+    return { name: spec }
+  }
 
   const name = spec.slice(0, colon)
   const rangePart = spec.slice(colon + 1)
@@ -94,6 +105,11 @@ export function parseTranscriptSpec(spec: string): TranscriptSpec {
   if (!name || !match) {
     throw new Error(
       `Invalid --transcript spec "${spec}" — expected "<name>" or "<name>:<start>-<end>"`
+    )
+  }
+  if (!TRANSCRIPT_NAME_RE.test(name)) {
+    throw new Error(
+      `Invalid transcript name "${name}" — only letters, digits, "_" and "-" are allowed`
     )
   }
 
@@ -150,6 +166,11 @@ export function parseStoryArgs(argv: string[]): StoryArgs {
 
   if (transcripts.length === 0) throw new Error("At least one --transcript is required")
   if (!story) throw new Error("--story is required (kebab-case id, e.g. poor-child)")
+  if (!STORY_ID_RE.test(story)) {
+    throw new Error(
+      `Invalid --story "${story}" — must be a kebab-case id (lowercase letters/digits/hyphens, e.g. poor-child)`
+    )
+  }
   if (!title) throw new Error("--title is required")
   if (!decade) throw new Error("--decade is required (e.g. 1930s)")
 


### PR DESCRIPTION
Closes #10.

## What

Codifies the manual moon-landing draft process into a repeatable pipeline stage: `tomasa/scripts/generate-story.ts` turns labeled transcript beats into a narrative story draft.

- **Input:** labeled transcript(s) + beat selection + story metadata
  - `--transcript <name>:<start>-<end>` — explicit segment-id range
  - `--theme "<theme>"` — Claude-assisted beat selection across transcripts (chunked scan → contiguous runs)
  - `--story`, `--title`, `--decade`
- **Process:** `claude -p` subprocess (same pattern as `add-speaker-labels.ts` / `fill-transcript-gaps.ts`): JSON-only response protocol, CRLF/fence-tolerant parsing, retries with exponential backoff.
- **Output:** `apps/tomasa/src/content/drafts/<story>.md` with `draft-v1` frontmatter — `story`, `title`, `decade`, `sources` (transcript + segment range, built deterministically by the script so citations are always accurate), `emotional-spine`, `open-questions`, `voice-check: pending`. Resume-by-output-existence; `--force` to regenerate. `TOMASA_DATA_DIR` honored for worktree runs.

## Docs

`tomasa/docs/story-generation.md` documents the workflow, output shape, and the **mandatory human voice-check** (read aloud with a Spanish speaker, resolve open-questions with family) before any draft is integrated into `decades.ts` — per the issue's acceptance criteria.

## Tests

- `scripts/generate-story.test.ts`: 32 cases over the exported pure helpers (arg parsing, range selection, run grouping, frontmatter, JSON extraction). Full suite: 55 pass / 0 fail.
- End-to-end smoke test with a stubbed `claude` binary and fixture transcript verified beat selection, drafting, frontmatter, and idempotent re-run.

Note: the acceptance run for "poor child 1930s" needs the local machine — `data/labeled-transcripts/` is gitignored and only exists there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZpY5Mh6mw1ph5GWyUdR8g

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZpY5Mh6mw1ph5GWyUdR8g)_